### PR TITLE
Adding a helpful message when twitter.operation is missing

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/twitter/poll/TwitterStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/twitter/poll/TwitterStreamData.java
@@ -239,21 +239,25 @@ public class TwitterStreamData extends GenericPollingConsumer {
                 configurationBuilder.build()).getInstance();
         String twitterOperation = properties
                 .getProperty(TwitterConstant.TWITTER_OPERATION);
-        if (twitterOperation.equals(TwitterConstant.FILTER_STREAM_OPERATION)
-                || twitterOperation.equals(TwitterConstant.FIREHOSE_STREAM_OPERATION)
-                || twitterOperation.equals(TwitterConstant.LINK_STREAM_OPERATION)
-                || twitterOperation.equals(TwitterConstant.SAMPLE_STREAM_OPERATION)
-                || twitterOperation.equals(TwitterConstant.RETWEET_STREAM_OPERATION)) {
-            statusStreamsListener = new StatusListenerImpl();
-            twitterStream.addListener(statusStreamsListener);
-        } else if (twitterOperation.equals(TwitterConstant.USER_STREAM_OPERATION)) {
-            userStreamListener = new UserStreamListenerImpl();
-            twitterStream.addListener(userStreamListener);
-        } else if (twitterOperation.equals(TwitterConstant.SITE_STREAM_OPERATION)) {
-            siteStreamslistener = new siteStreamsListenerImpl();
-            twitterStream.addListener(siteStreamslistener);
+        if (twitterOperation != null) {
+            if (twitterOperation.equals(TwitterConstant.FILTER_STREAM_OPERATION)
+                    || twitterOperation.equals(TwitterConstant.FIREHOSE_STREAM_OPERATION)
+                    || twitterOperation.equals(TwitterConstant.LINK_STREAM_OPERATION)
+                    || twitterOperation.equals(TwitterConstant.SAMPLE_STREAM_OPERATION)
+                    || twitterOperation.equals(TwitterConstant.RETWEET_STREAM_OPERATION)) {
+                statusStreamsListener = new StatusListenerImpl();
+                twitterStream.addListener(statusStreamsListener);
+            } else if (twitterOperation.equals(TwitterConstant.USER_STREAM_OPERATION)) {
+                userStreamListener = new UserStreamListenerImpl();
+                twitterStream.addListener(userStreamListener);
+            } else if (twitterOperation.equals(TwitterConstant.SITE_STREAM_OPERATION)) {
+                siteStreamslistener = new siteStreamsListenerImpl();
+                twitterStream.addListener(siteStreamslistener);
+            } else {
+                handleException("The operation :" + twitterOperation + " not found");
+            }
         } else {
-            handleException("The operation :" + twitterOperation + " not found");
+            handleException("The operation parameter not set");
         }
 
 		/* Synchronously retrieves public statuses that match one or more filter predicates.*/


### PR DESCRIPTION
## Purpose
Resolves issue#7

## Goals
Avoiding NullPointerException when operation parameter is not set

## Approach
Before operating on extracted operation value, performs a null check.
If value is null, logs a message asking to set the operation parameter.

## User stories
Adding Twitter inboud endpoint following [1], and not setting twitter.operation parameter.

[1] https://docs.wso2.com/display/ESBCONNECTORS/Configuring+Twitter+Inbound+Operations#ConfiguringTwitterInboundOperations-Properties

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Oracle JDK 1.8.0_251
ESB 4.9.0
EI 6.6.0
 
## Learning
N/A